### PR TITLE
FOLIO-2405 update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/openjdk8-jre:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-data-loader-fat.jar
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-data-loader
 
-Copyright (C) 2017-2018 The Open Library Foundation
+Copyright (C) 2017-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
Utilise the new base docker image "alpine-jre-openjdk8". This has recent Alpine Linux, recent Java 8, and has much smaller size. See [FOLIO-2405](https://issues.folio.org/browse/FOLIO-2405).